### PR TITLE
Fixed an issue where only interfaces were found unconditionally when there was no to/from option.

### DIFF
--- a/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/core/Utils.kt
+++ b/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/core/Utils.kt
@@ -1,0 +1,10 @@
+package com.smparkworld.hiltbinder_processor.core
+
+import com.squareup.javapoet.ClassName
+import javax.lang.model.type.TypeMirror
+
+internal object Utils {
+
+    fun isObjectClass(type: TypeMirror): Boolean =
+        type.toString() == ClassName.get(Object::class.java).canonicalName()
+}

--- a/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/extension/ElementExt.kt
+++ b/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/extension/ElementExt.kt
@@ -1,5 +1,6 @@
 package com.smparkworld.hiltbinder_processor.extension
 
+import com.smparkworld.hiltbinder_processor.core.Utils
 import com.squareup.javapoet.ClassName
 import javax.annotation.processing.ProcessingEnvironment
 import javax.lang.model.element.Element
@@ -10,8 +11,20 @@ import javax.lang.model.type.TypeMirror
 internal fun Element.asClassName(env: ProcessingEnvironment): ClassName =
     env.getClassName(this)
 
+internal fun Element.getSuperTypeMirror(): TypeMirror? {
+    val superClass = (this as? TypeElement)?.superclass
+    if (superClass != null && !Utils.isObjectClass(superClass)) {
+        return superClass
+    }
+    val superInterface = (this as? TypeElement)?.interfaces?.getOrNull(0)
+    if (superInterface != null) {
+        return superInterface
+    }
+    return null
+}
+
 internal fun Element.getGenericTypes(env: ProcessingEnvironment): List<Element> =
-    (this as TypeElement).interfaces[0].let { type ->
+    getSuperTypeMirror().let { type ->
         (type as DeclaredType).typeArguments.map {
             env.typeUtils.asElement(it)
         }

--- a/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/extension/ProcssingExt.kt
+++ b/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/extension/ProcssingExt.kt
@@ -15,8 +15,5 @@ internal fun ProcessingEnvironment.error(message: String) =
 internal fun ProcessingEnvironment.getClassName(element: Element): ClassName =
     ClassName.get(getPackageName(element), element.simpleName.toString())
 
-internal fun ProcessingEnvironment.getSuperInterfaceElement(element: Element): Element =
-    typeUtils.asElement((element as TypeElement).interfaces[0])
-
 internal fun ProcessingEnvironment.getPackageName(element: Element): String =
     elementUtils.getPackageOf(element).toString()

--- a/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/extension/TypeMirrorExt.kt
+++ b/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/extension/TypeMirrorExt.kt
@@ -1,0 +1,8 @@
+package com.smparkworld.hiltbinder_processor.extension
+
+import javax.annotation.processing.ProcessingEnvironment
+import javax.lang.model.element.Element
+import javax.lang.model.type.TypeMirror
+
+internal fun TypeMirror.asElement(env: ProcessingEnvironment): Element =
+    env.typeUtils.asElement(this)

--- a/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/generator/hiltbinds/HiltBindsParameterMapper.kt
+++ b/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/generator/hiltbinds/HiltBindsParameterMapper.kt
@@ -3,9 +3,10 @@ package com.smparkworld.hiltbinder_processor.generator.hiltbinds
 import com.smparkworld.hiltbinder.HiltBinds
 import com.smparkworld.hiltbinder_processor.core.base.ParameterMapper
 import com.smparkworld.hiltbinder_processor.core.manager.AnnotationManager
+import com.smparkworld.hiltbinder_processor.extension.asElement
 import com.smparkworld.hiltbinder_processor.extension.error
 import com.smparkworld.hiltbinder_processor.extension.getGenericTypes
-import com.smparkworld.hiltbinder_processor.extension.getSuperInterfaceElement
+import com.smparkworld.hiltbinder_processor.extension.getSuperTypeMirror
 import com.smparkworld.hiltbinder_processor.model.HiltBindsParamsModel
 import javax.annotation.processing.ProcessingEnvironment
 import javax.inject.Named
@@ -43,8 +44,14 @@ internal class HiltBindsParameterMapper : ParameterMapper<HiltBindsParamsModel> 
                 )
             }
             (paramFrom == null && paramTo == null) -> {
+                val to = element.getSuperTypeMirror()?.asElement(env)
+                if (to == null) {
+                    env.error(ERROR_MSG_NOT_FOUND_SUPER)
+                    throw IllegalStateException(ERROR_MSG_NOT_FOUND_SUPER)
+                }
+
                 HiltBindsParamsModel(
-                    env.getSuperInterfaceElement(element),
+                    to,
                     element,
                     paramComponent,
                     qualifier,
@@ -61,6 +68,8 @@ internal class HiltBindsParameterMapper : ParameterMapper<HiltBindsParamsModel> 
 
     companion object {
         private const val ERROR_MSG_SIGNED_TOGETHER = "`to` and `from` cannot be signed together."
+        private const val ERROR_MSG_NOT_FOUND_SUPER = "Super class not found."
+
 
         private const val PARAM_TO = "to"
         private const val PARAM_FROM = "from"

--- a/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/generator/hiltmapbinds/HiltMapBindsParameterMapper.kt
+++ b/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/generator/hiltmapbinds/HiltMapBindsParameterMapper.kt
@@ -3,8 +3,9 @@ package com.smparkworld.hiltbinder_processor.generator.hiltmapbinds
 import com.smparkworld.hiltbinder.HiltMapBinds
 import com.smparkworld.hiltbinder_processor.core.base.ParameterMapper
 import com.smparkworld.hiltbinder_processor.core.manager.AnnotationManager
+import com.smparkworld.hiltbinder_processor.extension.asElement
 import com.smparkworld.hiltbinder_processor.extension.error
-import com.smparkworld.hiltbinder_processor.extension.getSuperInterfaceElement
+import com.smparkworld.hiltbinder_processor.extension.getSuperTypeMirror
 import com.smparkworld.hiltbinder_processor.model.HiltMapBindsParamsModel
 import dagger.MapKey
 import javax.annotation.processing.ProcessingEnvironment
@@ -57,8 +58,14 @@ internal class HiltMapBindsParameterMapper : ParameterMapper<HiltMapBindsParamsM
                 )
             }
             (paramFrom == null && paramTo == null) -> {
+                val to = element.getSuperTypeMirror()?.asElement(env)
+                if (to == null) {
+                    env.error(ERROR_MSG_NOT_FOUND_SUPER)
+                    throw IllegalStateException(ERROR_MSG_NOT_FOUND_SUPER)
+                }
+
                 HiltMapBindsParamsModel(
-                    env.getSuperInterfaceElement(element),
+                    to,
                     element,
                     paramComponent,
                     qualifier,
@@ -78,6 +85,7 @@ internal class HiltMapBindsParameterMapper : ParameterMapper<HiltMapBindsParamsM
         private const val ERROR_MSG_NOT_FOUND_KEY = "@HiltMapBinds must have Key annotation."
         private const val ERROR_MSG_PARAMS_EMPTY = "key annotation must not be empty."
         private const val ERROR_MSG_SIGNED_TOGETHER = "`to` and `from` cannot be signed together."
+        private const val ERROR_MSG_NOT_FOUND_SUPER = "Super class not found."
 
         private const val PARAM_TO = "to"
         private const val PARAM_FROM = "from"

--- a/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/generator/hiltsetbinds/HiltSetBindsParameterMapper.kt
+++ b/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/generator/hiltsetbinds/HiltSetBindsParameterMapper.kt
@@ -3,9 +3,10 @@ package com.smparkworld.hiltbinder_processor.generator.hiltsetbinds
 import com.smparkworld.hiltbinder.HiltBinds
 import com.smparkworld.hiltbinder_processor.core.base.ParameterMapper
 import com.smparkworld.hiltbinder_processor.core.manager.AnnotationManager
+import com.smparkworld.hiltbinder_processor.extension.asElement
 import com.smparkworld.hiltbinder_processor.extension.error
 import com.smparkworld.hiltbinder_processor.extension.getGenericTypes
-import com.smparkworld.hiltbinder_processor.extension.getSuperInterfaceElement
+import com.smparkworld.hiltbinder_processor.extension.getSuperTypeMirror
 import com.smparkworld.hiltbinder_processor.model.HiltSetBindsParamsModel
 import javax.annotation.processing.ProcessingEnvironment
 import javax.inject.Named
@@ -43,8 +44,14 @@ internal class HiltSetBindsParameterMapper : ParameterMapper<HiltSetBindsParamsM
                 )
             }
             (paramFrom == null && paramTo == null) -> {
+                val to = element.getSuperTypeMirror()?.asElement(env)
+                if (to == null) {
+                    env.error(ERROR_MSG_NOT_FOUND_SUPER)
+                    throw IllegalStateException(ERROR_MSG_NOT_FOUND_SUPER)
+                }
+
                 HiltSetBindsParamsModel(
-                    env.getSuperInterfaceElement(element),
+                    to,
                     element,
                     paramComponent,
                     qualifier,
@@ -61,6 +68,7 @@ internal class HiltSetBindsParameterMapper : ParameterMapper<HiltSetBindsParamsM
 
     companion object {
         private const val ERROR_MSG_SIGNED_TOGETHER = "`to` and `from` cannot be signed together."
+        private const val ERROR_MSG_NOT_FOUND_SUPER = "Super class not found."
 
         private const val PARAM_TO = "to"
         private const val PARAM_FROM = "from"


### PR DESCRIPTION
Resolves issues https://github.com/Park-SM/HiltBinder/issues/23

- added Utils file.
- added error handling when don't unassigned to or from an option.
- applied the solution to each mapper class.