### PR TITLE
Improve to explicitly generate scope annotations.

### DIFF
--- a/app/src/main/java/com/smparkworld/hiltbinderexample/MainActivity.kt
+++ b/app/src/main/java/com/smparkworld/hiltbinderexample/MainActivity.kt
@@ -9,6 +9,7 @@ import com.smparkworld.hiltbinderexample.sample.basic.named.NamedSampleModel
 import com.smparkworld.hiltbinderexample.sample.basic.qualifier.QualifierSampleModel
 import com.smparkworld.hiltbinderexample.sample.basic.qualifier.SampleQualifierA
 import com.smparkworld.hiltbinderexample.sample.basic.qualifier.SampleQualifierB
+import com.smparkworld.hiltbinderexample.sample.basic.scope.ScopeSampleModel
 import com.smparkworld.hiltbinderexample.sample.basic.to.ToSampleModel
 import com.smparkworld.hiltbinderexample.sample.intomap.SampleKey
 import com.smparkworld.hiltbinderexample.sample.intomap.SampleType
@@ -76,6 +77,12 @@ class MainActivity : AppCompatActivity() {
     @Inject
     @Named("modelB")
     lateinit var namedSampleModelB: NamedSampleModel
+    ////////////////////////////////////////////
+
+    ////////////////////////////////////////////
+    // Basic usage - scoped
+    @Inject
+    lateinit var scopeSampleModel: ScopeSampleModel
     ////////////////////////////////////////////
 
 
@@ -224,6 +231,7 @@ class MainActivity : AppCompatActivity() {
         qualifierSampleModelB.printTestString()
         namedSampleModelA.printTestString()
         namedSampleModelB.printTestString()
+        scopeSampleModel.printTestString()
 
         sampleSet.forEach {
             it.printTestString()

--- a/app/src/main/java/com/smparkworld/hiltbinderexample/sample/basic/scope/ScopeSampleModel.kt
+++ b/app/src/main/java/com/smparkworld/hiltbinderexample/sample/basic/scope/ScopeSampleModel.kt
@@ -1,0 +1,6 @@
+package com.smparkworld.hiltbinderexample.sample.basic.scope
+
+interface ScopeSampleModel {
+
+    fun printTestString()
+}

--- a/app/src/main/java/com/smparkworld/hiltbinderexample/sample/basic/scope/ScopeSampleModelImpl.kt
+++ b/app/src/main/java/com/smparkworld/hiltbinderexample/sample/basic/scope/ScopeSampleModelImpl.kt
@@ -1,0 +1,18 @@
+package com.smparkworld.hiltbinderexample.sample.basic.scope
+
+import android.util.Log
+import com.smparkworld.hiltbinder.HiltBinds
+import dagger.hilt.android.components.ActivityRetainedComponent
+import dagger.hilt.android.scopes.ActivityRetainedScoped
+import javax.inject.Inject
+
+@HiltBinds(component = ActivityRetainedComponent::class)
+@ActivityRetainedScoped
+class ScopeSampleModelImpl @Inject constructor(
+    private val testString: String
+) : ScopeSampleModel {
+
+    override fun printTestString() {
+        Log.d("Test!!", "TestString is `$testString` in ScopeSampleModelImpl class.");
+    }
+}

--- a/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/generator/hiltbinds/HiltBindsModuleGenerator.kt
+++ b/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/generator/hiltbinds/HiltBindsModuleGenerator.kt
@@ -46,6 +46,7 @@ internal class HiltBindsModuleGenerator : ModuleGenerator {
 
         val spec = MethodSpec.methodBuilder("$FUN_PREFIX${element.simpleName}")
             .addAnnotation(Binds::class.java)
+            .addAnnotationIfNotNull(env, params.scope)
             .addAnnotationIfNotNull(env, params.qualifier)
             .addAnnotationIfNotNull(namedAnnotation)
             .addModifiers(Modifier.ABSTRACT, Modifier.PUBLIC)

--- a/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/generator/hiltbinds/HiltBindsParameterMapper.kt
+++ b/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/generator/hiltbinds/HiltBindsParameterMapper.kt
@@ -11,6 +11,7 @@ import com.smparkworld.hiltbinder_processor.model.HiltBindsParamsModel
 import javax.annotation.processing.ProcessingEnvironment
 import javax.inject.Named
 import javax.inject.Qualifier
+import javax.inject.Scope
 import javax.lang.model.element.Element
 
 internal class HiltBindsParameterMapper : ParameterMapper<HiltBindsParamsModel> {
@@ -20,6 +21,7 @@ internal class HiltBindsParameterMapper : ParameterMapper<HiltBindsParamsModel> 
         val paramFrom = AnnotationManager.getAnnotationValue<HiltBinds>(env, element, PARAM_FROM)
         val paramComponent = AnnotationManager.getAnnotationValue<HiltBinds>(env, element, PARAM_COMPONENT)
         val qualifier = AnnotationManager.getAnnotationByParentAnnotation(env, element, Qualifier::class, Named::class)
+        val scope = AnnotationManager.getAnnotationByParentAnnotation(env, element, Scope::class)
         val namedValue = AnnotationManager.getAnnotationValues<Named>(env, element)?.get(NAMED_PARAM) as? String
 
         return when {
@@ -29,6 +31,7 @@ internal class HiltBindsParameterMapper : ParameterMapper<HiltBindsParamsModel> 
                     paramFrom.asClassName(env),
                     paramComponent,
                     qualifier,
+                    scope,
                     namedValue
                 )
             }
@@ -38,6 +41,7 @@ internal class HiltBindsParameterMapper : ParameterMapper<HiltBindsParamsModel> 
                     element.asClassName(env),
                     paramComponent,
                     qualifier,
+                    scope,
                     namedValue
                 )
             }
@@ -53,6 +57,7 @@ internal class HiltBindsParameterMapper : ParameterMapper<HiltBindsParamsModel> 
                     element.asClassName(env),
                     paramComponent,
                     qualifier,
+                    scope,
                     namedValue
                 )
             }

--- a/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/generator/hiltmapbinds/HiltMapBindsModuleGenerator.kt
+++ b/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/generator/hiltmapbinds/HiltMapBindsModuleGenerator.kt
@@ -86,6 +86,7 @@ internal class HiltMapBindsModuleGenerator : ModuleGenerator {
             .addAnnotation(Binds::class.java)
             .addAnnotation(IntoMap::class.java)
             .addAnnotation(mapKeyAnnotation)
+            .addAnnotationIfNotNull(env, params.scope)
             .addAnnotationIfNotNull(env, params.qualifier)
             .addAnnotationIfNotNull(namedAnnotation)
             .addModifiers(Modifier.ABSTRACT, Modifier.PUBLIC)

--- a/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/generator/hiltmapbinds/HiltMapBindsParameterMapper.kt
+++ b/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/generator/hiltmapbinds/HiltMapBindsParameterMapper.kt
@@ -12,6 +12,7 @@ import dagger.MapKey
 import javax.annotation.processing.ProcessingEnvironment
 import javax.inject.Named
 import javax.inject.Qualifier
+import javax.inject.Scope
 import javax.lang.model.element.Element
 
 internal class HiltMapBindsParameterMapper : ParameterMapper<HiltMapBindsParamsModel> {
@@ -20,9 +21,10 @@ internal class HiltMapBindsParameterMapper : ParameterMapper<HiltMapBindsParamsM
         val paramTo = AnnotationManager.getAnnotationValue<HiltMapBinds>(env, element, PARAM_TO)
         val paramFrom = AnnotationManager.getAnnotationValue<HiltMapBinds>(env, element, PARAM_FROM)
         val paramComponent = AnnotationManager.getAnnotationValue<HiltMapBinds>(env, element, PARAM_COMPONENT)
-
         val qualifier = AnnotationManager.getAnnotationByParentAnnotation(env, element, Qualifier::class, Named::class)
+        val scope = AnnotationManager.getAnnotationByParentAnnotation(env, element, Scope::class)
         val namedValue = AnnotationManager.getAnnotationValues<Named>(env, element)?.get(NAMED_PARAM) as? String
+
         val mapKey = AnnotationManager.getAnnotationByParentAnnotation(env, element, MapKey::class)
         val mapKeyParams = AnnotationManager.getAnnotationValuesByParentAnnotation(env, element, MapKey::class)
 
@@ -42,6 +44,7 @@ internal class HiltMapBindsParameterMapper : ParameterMapper<HiltMapBindsParamsM
                     paramFrom.asClassName(env),
                     paramComponent,
                     qualifier,
+                    scope,
                     namedValue,
                     mapKey,
                     mapKeyParams
@@ -53,6 +56,7 @@ internal class HiltMapBindsParameterMapper : ParameterMapper<HiltMapBindsParamsM
                     element.asClassName(env),
                     paramComponent,
                     qualifier,
+                    scope,
                     namedValue,
                     mapKey,
                     mapKeyParams
@@ -70,6 +74,7 @@ internal class HiltMapBindsParameterMapper : ParameterMapper<HiltMapBindsParamsM
                     element.asClassName(env),
                     paramComponent,
                     qualifier,
+                    scope,
                     namedValue,
                     mapKey,
                     mapKeyParams

--- a/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/generator/hiltsetbinds/HiltSetBindsModuleGenerator.kt
+++ b/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/generator/hiltsetbinds/HiltSetBindsModuleGenerator.kt
@@ -48,6 +48,7 @@ internal class HiltSetBindsModuleGenerator : ModuleGenerator {
         val spec = MethodSpec.methodBuilder("$FUN_PREFIX${element.simpleName}")
             .addAnnotation(Binds::class.java)
             .addAnnotation(IntoSet::class.java)
+            .addAnnotationIfNotNull(env, params.scope)
             .addAnnotationIfNotNull(env, params.qualifier)
             .addAnnotationIfNotNull(namedAnnotation)
             .addModifiers(Modifier.ABSTRACT, Modifier.PUBLIC)

--- a/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/generator/hiltsetbinds/HiltSetBindsParameterMapper.kt
+++ b/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/generator/hiltsetbinds/HiltSetBindsParameterMapper.kt
@@ -1,6 +1,6 @@
 package com.smparkworld.hiltbinder_processor.generator.hiltsetbinds
 
-import com.smparkworld.hiltbinder.HiltBinds
+import com.smparkworld.hiltbinder.HiltSetBinds
 import com.smparkworld.hiltbinder_processor.core.base.ParameterMapper
 import com.smparkworld.hiltbinder_processor.core.manager.AnnotationManager
 import com.smparkworld.hiltbinder_processor.extension.asClassName
@@ -11,15 +11,17 @@ import com.smparkworld.hiltbinder_processor.model.HiltSetBindsParamsModel
 import javax.annotation.processing.ProcessingEnvironment
 import javax.inject.Named
 import javax.inject.Qualifier
+import javax.inject.Scope
 import javax.lang.model.element.Element
 
 internal class HiltSetBindsParameterMapper : ParameterMapper<HiltSetBindsParamsModel> {
 
     override fun toParamsModel(env: ProcessingEnvironment, element: Element): HiltSetBindsParamsModel {
-        val paramTo = AnnotationManager.getAnnotationValue<HiltBinds>(env, element, PARAM_TO)
-        val paramFrom = AnnotationManager.getAnnotationValue<HiltBinds>(env, element, PARAM_FROM)
-        val paramComponent = AnnotationManager.getAnnotationValue<HiltBinds>(env, element, PARAM_COMPONENT)
+        val paramTo = AnnotationManager.getAnnotationValue<HiltSetBinds>(env, element, PARAM_TO)
+        val paramFrom = AnnotationManager.getAnnotationValue<HiltSetBinds>(env, element, PARAM_FROM)
+        val paramComponent = AnnotationManager.getAnnotationValue<HiltSetBinds>(env, element, PARAM_COMPONENT)
         val qualifier = AnnotationManager.getAnnotationByParentAnnotation(env, element, Qualifier::class, Named::class)
+        val scope = AnnotationManager.getAnnotationByParentAnnotation(env, element, Scope::class)
         val namedValue = AnnotationManager.getAnnotationValues<Named>(env, element)?.get(NAMED_PARAM) as? String
 
         return when {
@@ -29,6 +31,7 @@ internal class HiltSetBindsParameterMapper : ParameterMapper<HiltSetBindsParamsM
                     paramFrom.asClassName(env),
                     paramComponent,
                     qualifier,
+                    scope,
                     namedValue
                 )
             }
@@ -38,6 +41,7 @@ internal class HiltSetBindsParameterMapper : ParameterMapper<HiltSetBindsParamsM
                     element.asClassName(env),
                     paramComponent,
                     qualifier,
+                    scope,
                     namedValue
                 )
             }
@@ -53,6 +57,7 @@ internal class HiltSetBindsParameterMapper : ParameterMapper<HiltSetBindsParamsM
                     element.asClassName(env),
                     paramComponent,
                     qualifier,
+                    scope,
                     namedValue
                 )
             }

--- a/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/model/HiltBindsParamsModel.kt
+++ b/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/model/HiltBindsParamsModel.kt
@@ -9,5 +9,6 @@ internal data class HiltBindsParamsModel(
     val from: TypeName,
     val component: Element? = null,
     val qualifier: Element? = null,
+    val scope: Element? = null,
     val namedValue: String? = null
 ) : ParametersModel

--- a/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/model/HiltMapBindsParamsModel.kt
+++ b/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/model/HiltMapBindsParamsModel.kt
@@ -9,6 +9,7 @@ internal data class HiltMapBindsParamsModel(
     val from: TypeName,
     val component: Element? = null,
     val qualifier: Element? = null,
+    val scope: Element? = null,
     val namedValue: String? = null,
     val mapKey: Element,
     val mapKeyParams: Map<String, Any>

--- a/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/model/HiltSetBindsParamsModel.kt
+++ b/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/model/HiltSetBindsParamsModel.kt
@@ -9,5 +9,6 @@ internal data class HiltSetBindsParamsModel(
     val from: TypeName,
     val component: Element? = null,
     val qualifier: Element? = null,
+    val scope: Element? = null,
     val namedValue: String? = null
 ) : ParametersModel


### PR DESCRIPTION
Resolves issues https://github.com/Park-SM/HiltBinder/issues/29

- change target annotation to HiltSetBinds class in HiltSetBindsParameterMapper class.