### PR TITLE
If use the ClassKey provided by Hilt, cannot use the interface class type.

### DIFF
--- a/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/generator/hiltmapbinds/HiltMapBindsModuleGenerator.kt
+++ b/hiltbinder-processor/src/main/java/com/smparkworld/hiltbinder_processor/generator/hiltmapbinds/HiltMapBindsModuleGenerator.kt
@@ -51,7 +51,8 @@ internal class HiltMapBindsModuleGenerator : ModuleGenerator {
                     when (value) {
                         is Element -> {
                             when(value.kind) {
-                                ElementKind.CLASS -> {
+                                ElementKind.CLASS,
+                                ElementKind.INTERFACE -> {
                                     addMember(key, "\$T.class", value)
                                 }
                                 ElementKind.ENUM_CONSTANT -> {


### PR DESCRIPTION
Resolves issues https://github.com/Park-SM/HiltBinder/issues/31